### PR TITLE
Spelling error in macro ADAPT_PURGE_MOD

### DIFF
--- a/files/kamp/Start_Print.cfg
+++ b/files/kamp/Start_Print.cfg
@@ -125,7 +125,7 @@ gcode:
   {% endif %}
 
   
-[gcoce_macro ADAPT_PURGE_MOD]
+[gcode_macro ADAPT_PURGE_MOD]
 gcode:
   {% if printer['output_pin ADAPTIVE_PURGE_LINE'].value == 1 %}
     _SMART_PARK


### PR DESCRIPTION
Corrected spelling error in macro definition which would generate an error at startup of Klipper