### PR TITLE
Fixed is not a valid config

### DIFF
--- a/files/kamp/Start_Print.cfg
+++ b/files/kamp/Start_Print.cfg
@@ -125,7 +125,7 @@ gcode:
   {% endif %}
 
   
-[gcoce_macro ADAPT_PURGE_MOD]
+[gcode_macro ADAPT_PURGE_MOD]
 gcode:
   {% if printer['output_pin ADAPTIVE_PURGE_LINE'].value == 1 %}
     _SMART_PARK


### PR DESCRIPTION
{"code": "key341", "msg": "Section 'gcoce_macro adapt_purge_mod' is not a valid config section\n\nOnce the underlying issue is corrected, use the \"RESTART\"\ncommand to reload the config and restart the host software.\nPrinter is halted\n", "values": ["gcoce_macro adapt_purge_mod"]}