### PR TITLE
Modifications to kamp/Start_Print.cfg to address mesh and bed temperature issues

### DIFF
--- a/files/kamp/Start_Print.cfg
+++ b/files/kamp/Start_Print.cfg
@@ -81,7 +81,9 @@ gcode:
 [gcode_macro START_PRINT]
 variable_prepare: 0
 gcode:
+  RESPOND TYPE=command MSG="DEBUG: BOX_START_PRINT macro commencing"
   BOX_START_PRINT
+  RESPOND TYPE=command MSG="DEBUG: BOX_START_PRINT complete - resuming balance of START_PRINT commands"
   G90
   WAIT_TEMP_END
   CLEAR_PAUSE
@@ -96,36 +98,62 @@ gcode:
   {% if 'EXTRUDER_TEMP' in params|upper and (params.EXTRUDER_TEMP|float) %}
     {% set extruder_temp = params.EXTRUDER_TEMP %}
   {% endif %}
-  
+
   {% if printer['gcode_macro START_PRINT'].prepare|int == 0 %}
+    RESPOND TYPE=command MSG="DEBUG: prepare=0 path, doing full home sequence"
     {action_respond_info("not prepare.\n")}
     PRINT_PREPARE_CLEAR
     CX_ROUGH_G28 EXTRUDER_TEMP={extruder_temp} BED_TEMP={bed_temp}
-    CX_NOZZLE_CLEAR
-    ACCURATE_G28
-    {% if printer['output_pin ADAPTIVE_BED_MESH'].value == 1 %}
-      RESPOND TYPE=command MSG="Starting Adaptive Bed Mesh..."
-      BED_MESH_CLEAR
-      BED_MESH_CALIBRATE
-      BED_MESH_PROFILE SAVE=adaptive
-      BED_MESH_PROFILE LOAD=adaptive
-    {% else %}
-      {% if printer['output_pin FULL_BED_MESH'].value == 0 and (not printer['bed_mesh'].profile_name) %}
-        RESPOND TYPE=command MSG="No bed mesh found. Starting Full Bed Mesh..."
-        CX_PRINT_LEVELING_CALIBRATION
-      {% endif %}
-      {% if printer['output_pin FULL_BED_MESH'].value == 1 %}
-        RESPOND TYPE=command MSG="Starting Full Bed Mesh..."
-        CX_PRINT_LEVELING_CALIBRATION
-      {% endif %}
-      BED_MESH_PROFILE LOAD=default
-    {% endif %}
+    #CX_NOZZLE_CLEAR        # Moving to after heat soak
+    #ACCURATE_G28
   {% else %}
+    RESPOND TYPE=command MSG="DEBUG: prepare=1 path, BOX_START_PRINT already homed"
     PRINT_PREPARE_CLEAR
   {% endif %}
 
+  # --- HEAT SOAK AND STABILIZE ---
+  RESPOND TYPE=command MSG="DEBUG: Waiting for bed to reach {bed_temp}C before mesh..."
+  M140 S{bed_temp}
+  M109 S{g28_extruder_temp}
+  M190 S{bed_temp}
+
+  # --- Add a 2-minute dwell for high temperature beds to let the expansion settle ---
+  {% if bed_temp|int >= 75 %}
+    RESPOND TYPE=command MSG="DEBUG: High temp bed detected, soaking for 2 minutes..."
+    G4 P120000 
+  {% endif %}
+
+  # --- RE-ZERO AFTER HEAT SOAK ---
+  RESPOND TYPE=command MSG="DEBUG: Cleaning nozzle and re-homing Z at temp"
+  CX_NOZZLE_CLEAR BED_TEMP={bed_temp}   # Clean off any ooze that happened during heating -- Ensure we pass the bed temperature to avoid unncessary wait times and heat cycles!
+  ACCURATE_G28                          # Re-establishes Z=0 now that the bed is heated up
+
+  RESPOND TYPE=command MSG="DEBUG: Bed at target and re-homed, starting mesh"
+
+  {% if printer['output_pin ADAPTIVE_BED_MESH'].value == 1 %}
+    RESPOND TYPE=command MSG="Starting Adaptive Bed Mesh..."
+    BED_MESH_CLEAR
+    BED_MESH_CALIBRATE
+    BED_MESH_PROFILE SAVE=adaptive
+    BED_MESH_PROFILE LOAD=adaptive
+  {% else %}
+    {% if printer['output_pin FULL_BED_MESH'].value == 0 and (not printer['bed_mesh'].profile_name) %}
+      RESPOND TYPE=command MSG="No bed mesh found. Starting Full Bed Mesh..."
+      CX_PRINT_LEVELING_CALIBRATION
+    {% endif %}
+    {% if printer['output_pin FULL_BED_MESH'].value == 1 %}
+      RESPOND TYPE=command MSG="Starting Full Bed Mesh..."
+      CX_PRINT_LEVELING_CALIBRATION
+    {% endif %}
+    BED_MESH_PROFILE LOAD=default
+  {% endif %}
+
+  RESPOND TYPE=command MSG="DEBUG: Mesh complete, reheating nozzle to {extruder_temp}C for purge"
+  M109 S{extruder_temp}
   
-[gcoce_macro ADAPT_PURGE_MOD]
+  ADAPT_PURGE_MOD
+  
+[gcode_macro ADAPT_PURGE_MOD]
 gcode:
   {% if printer['output_pin ADAPTIVE_PURGE_LINE'].value == 1 %}
     _SMART_PARK


### PR DESCRIPTION
**Thermal Stability:** Added BED_TEMP={bed_temp} to the CX_NOZZLE_CLEAR call to prevent the bed from reverting to default temperatures during the cleaning cycle.

**Heat Soak Dwell:** Added a conditional 2-minute soak (G4 P120000) for bed temperatures ≥75°C to allow for thermal expansion before homing/probing.

**Logic Optimization:** Reordered the sequence to ensure the nozzle is cleared, Z is re-homed (ACCURATE_G28) and bed leveling occurs after the bed has reached target temperature and stabilized.

**Debug Logging:** Added RESPOND messages to the console to provide better visibility into the macro's progress and the "prepare" logic path.